### PR TITLE
Set selinux permissive mode

### DIFF
--- a/testenv/bootbox/puppet/manifests/bootbox.pp.sample
+++ b/testenv/bootbox/puppet/manifests/bootbox.pp.sample
@@ -23,4 +23,5 @@ node default {
     include ipxe
     include iptables
     include genesis
+    include selinux::permissive
 }

--- a/testenv/bootbox/puppet/modules/dhcp/manifests/server.pp
+++ b/testenv/bootbox/puppet/modules/dhcp/manifests/server.pp
@@ -11,7 +11,10 @@ class dhcp::server {
   service { 'dhcpd':
     ensure  => running,
     enable  => true,
-    require => File['/etc/dhcp/dhcpd.conf'];
+    require => [
+                File['/etc/dhcp/dhcpd.conf'],
+                Exec['set selinux permissive mode']
+               ];
   }
 
   Package['dhcp'] -> File['/etc/dhcp/dhcpd.conf']

--- a/testenv/bootbox/puppet/modules/selinux/manifests/permissive.pp
+++ b/testenv/bootbox/puppet/modules/selinux/manifests/permissive.pp
@@ -1,0 +1,6 @@
+class selinux::permissive {
+  exec { 'set selinux permissive mode':
+    command => '/usr/sbin/setenforce 0',
+    onlyif  => '/usr/sbin/sestatus | /bin/egrep "Current mode: +enforcing"';
+  }
+}


### PR DESCRIPTION
SELinux seems to cause the strange behavior you saw with starting dhcpd, @roymarantz. This sets the mode to permissive before starting dhcpd.
