### PR TITLE
revert the change to tty.conf.override since it doesn't fix

### DIFF
--- a/bootcd/rpms/genesis_scripts/genesis_scripts.spec
+++ b/bootcd/rpms/genesis_scripts/genesis_scripts.spec
@@ -1,6 +1,6 @@
 Name:           genesis_scripts
 Version:        0.5
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache License, 2.0
 URL:            http://tumblr.github.io/genesis
 BuildArch:      noarch
@@ -58,6 +58,8 @@ install -m 555 -T %{SOURCE4}   $RPM_BUILD_ROOT/usr/bin/genesis-bootloader
 
 %post 
 cat /root/.bash_profile.genesis_scripts >> /root/.bash_profile
+# TODO undo this hack
+cp  /etc/init/tty.conf.override /etc/init/tty.conf
 /usr/bin/patch /etc/sysconfig/init < /etc/sysconfig/init.diff
 chkconfig --add network-prep
 

--- a/bootcd/rpms/genesis_scripts/src/tty.conf.override
+++ b/bootcd/rpms/genesis_scripts/src/tty.conf.override
@@ -9,6 +9,7 @@ stop on runlevel [S016]
 
 respawn
 instance $TTY
-exec /sbin/agetty -8 -n -l /root/login-shell 115200 $TTY
-#exec /sbin/mingetty --autologin root $TTY
+# TODO fix this to connect to the console
+exec /sbin/mingetty --autologin root $TTY
+#exec /sbin/agetty -8 -n -l /root/login-shell 115200 $TTY
 usage 'tty TTY=/dev/ttyX  - where X is console id'


### PR DESCRIPTION
genesis-bootloader not running on the console
