### PR TITLE
fix gem install optimization

### DIFF
--- a/src/framework/genesis_framework.gemspec
+++ b/src/framework/genesis_framework.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email = 'opensourcesoftware@tumblr.com'
 
   gem.date = '2014-12-29'
-  gem.version = '0.5.2'
+  gem.version = '0.5.3'
   gem.add_dependency('genesis_promptcli', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('genesis_retryingfetcher', '~> 0.4', '>= 0.4.0')
   gem.add_dependency('collins_client', '~> 0.2', '>= 0.2.0')

--- a/tasks/DSL.md
+++ b/tasks/DSL.md
@@ -67,7 +67,7 @@ Example:
 * `install provider, *what`
 
 Uses either the **yum** provider or the **gem** provider to (possibly) install
-software.
+software.  Installing a **gem** also does a `require` of it in the Ruby task class.
 
 Example:
 [TimedBurnin.rb](https://github.com/tumblr/genesis/blob/master/tasks/TimedBurnin.rb#L13)


### PR DESCRIPTION
install :gem, 'Gem name' filters out already installed gems from its work list, but doesn't handle the case where all gems are installed already.
