### PR TITLE
Put back /root/repo/gems removed by livecd cleanup.

### DIFF
--- a/testenv/bootbox/puppet/modules/genesis/templates/stage2.erb
+++ b/testenv/bootbox/puppet/modules/genesis/templates/stage2.erb
@@ -35,6 +35,8 @@ end
 
 puts "\nEnsuring temp directory for downloads exists"
 Dir.mkdir("tmp", 0755) unless File.directory? "tmp"
+Dir.mkdir("/root/repo", 0755) unless File.directory? "/root/repo"
+Dir.mkdir("/root/repo/gems", 0755) unless File.directory? "/root/repo/gems"
 
 puts ''
 # protect against funny configs


### PR DESCRIPTION
stage2.erb is trying to download gems to a directory that doesn't exist, this PR restores the directory that was previously removed by the livecd cleanup.