### PR TITLE
explicitly bring up only one interface now to prevent

### DIFF
--- a/bootcd/rpms/genesis_scripts/genesis_scripts.spec
+++ b/bootcd/rpms/genesis_scripts/genesis_scripts.spec
@@ -1,5 +1,5 @@
 Name:           genesis_scripts
-Version:        0.5
+Version:        0.6
 Release:        4%{?dist}
 License:        Apache License, 2.0
 URL:            http://tumblr.github.io/genesis

--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -24,7 +24,7 @@ EOF
 	    # explicitly bring up only one interface now to prevent
 	    # using lots of dhcp dynamic addresses
 	    # and avoid routing issues with multiple interface on same network
-	    [[ -n network_up ]] && /sbin/ifup $int && network_up="$int"
+	    [[ -n network_up ]] && ip link set dev $int up && network_up="$int"
 	done
 	;;
     *)  ;;

--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -24,7 +24,7 @@ EOF
 	    # explicitly bring up only one interface now to prevent
 	    # using lots of dhcp dynamic addresses
 	    # and avoid routing issues with multiple interface on same network
-	    [[ -n network_up ]] && ip link set dev $int up && network_up="$int"
+	    [[ -n network_up ]] && /sbin/dhclient $int && network_up="$int"
 	done
 	;;
     *)  ;;

--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -18,9 +18,13 @@ case "$1" in
 	    cat > /etc/sysconfig/network-scripts/ifcfg-$int <<EOF
 DEVICE=$int
 BOOTPROTO=dhcp
-ONBOOT=yes
+ONBOOT=no
 NAME=nic
 EOF
+	    # explicitly bring up only one interface now to prevent
+	    # using lots of dhcp dynamic addresses
+	    # and avoid routing issues with multiple interface on same network
+	    [[ -n network_up ]] && /sbin/ifup $int && network_up="$int"
 	done
 	;;
     *)  ;;


### PR DESCRIPTION
using lots of dhcp dynamic addresses  GEN-13
and avoid routing issues with multiple interface on same network SYSSRE-3163

This has been tested by running:
/etc/init.d/network stop
for f in /etc/sysconfig/network-scripts/ifcfg-eth*; do
sed -i s/yes/no/ $f
end
/sbin/ifup eth0
ip addr to get the assigned address
ping succeeds on that address from dhcp.ewr01 and a node on the same network