### PR TITLE
Fix network setup

### DIFF
--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -13,7 +13,7 @@
 
 case "$1" in
     start)
-	for int in `ip link | grep -v lo0 | awk '/ qlen / {print $2}' | sed 's/://g'`
+	for int in `ip link | grep -v lo | awk '/ qlen / {print $2}' | sed 's/://g'`
 	do
 	    cat > /etc/sysconfig/network-scripts/ifcfg-$int <<EOF
 DEVICE=$int

--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -24,7 +24,7 @@ EOF
 	    # explicitly bring up only one interface now to prevent
 	    # using lots of dhcp dynamic addresses
 	    # and avoid routing issues with multiple interface on same network
-	    [[ -n network_up ]] && /sbin/dhclient $int && network_up="$int"
+	    [[ -n network_up ]] && /sbin/dhclient -1 -d -timeout 15 $int && network_up="$int"
 	done
 	;;
     *)  ;;

--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -24,7 +24,7 @@ EOF
 	    # explicitly bring up only one interface now to prevent
 	    # using lots of dhcp dynamic addresses
 	    # and avoid routing issues with multiple interface on same network
-	    [[ -n network_up ]] && /sbin/dhclient -1 -d -timeout 15 $int && network_up="$int"
+	    [[ -z "$network_up" ]] && /sbin/dhclient -1 -d -timeout 15 $int && network_up="$int"
 	done
 	;;
     *)  ;;


### PR DESCRIPTION
Previously `dhclient` would daemonize after not getting any offers, and it would not start up for other interfaces. This adds flags to `dhclient` to only try once before exiting (`-1`), not daemonizing (`-d`) and setting a 15 second timeout.

This also fixes an error in the conditional that is supposed to break the loop if we get a DHCP offer on one interface, as well as fixes a small error where we try to exclude loopback by doing `grep -v lo0` when it's actually named `lo`.

@roymarantz @byxorna @Primer42 @maddalab 