### PR TITLE
Remove -d flag from dhclient

### DIFF
--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -24,7 +24,7 @@ EOF
 	    # explicitly bring up only one interface now to prevent
 	    # using lots of dhcp dynamic addresses
 	    # and avoid routing issues with multiple interface on same network
-	    [[ -z "$network_up" ]] && /sbin/dhclient -1 -d -timeout 15 $int && network_up="$int"
+	    [[ -z "$network_up" ]] && /sbin/dhclient -1 -timeout 15 $int && network_up="$int"
 	done
 	;;
     *)  ;;

--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -24,7 +24,7 @@ EOF
 	    # explicitly bring up only one interface now to prevent
 	    # using lots of dhcp dynamic addresses
 	    # and avoid routing issues with multiple interface on same network
-	    [[ -z "$network_up" ]] && /sbin/dhclient -1 -timeout 15 $int && network_up="$int"
+	    [[ -z "$network_up" ]] && /sbin/dhclient -1 $int && network_up="$int"
 	done
 	;;
     *)  ;;


### PR DESCRIPTION
Fixing a stupid error I introduced in #32. `-d` will keep dhclient in the foreground.

We want dhclient to go in to the background and manage the interface that gets the first DHCP offer. Using just `-1` will make dhclient try once and exit with code 2 if it fails, otherwise daemonize it self and manage DHCP as usual.

@roymarantz @Primer42 @byxorna 