### PR TITLE
rework how to not prompt for task execution when automatically invoked

### DIFF
--- a/bootcd/rpms/genesis_scripts/genesis_scripts.spec
+++ b/bootcd/rpms/genesis_scripts/genesis_scripts.spec
@@ -1,28 +1,28 @@
 Name:           genesis_scripts
-Version:        0.6
-Release:        4%{?dist}
+Version:        0.7
+Release:        1%{?dist}
 License:        Apache License, 2.0
 URL:            http://tumblr.github.io/genesis
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root
-Source0:        src/root-bash_profile 
+Source0:        src/root-bash_profile
 Source1:        src/init.d-network-prep
-Source2:        src/sysconfig-init.diff 
+Source2:        src/sysconfig-init.diff
 Source3:        src/tty.conf.override
 Source4:        src/genesis-bootloader
 Source5:        src/login-shell
 Summary:        Scripts used by Genesis in the bootcd image
-Group:          System Environment/Base  
+Group:          System Environment/Base
 Requires:       initscripts rootfiles patch
 
 %description
 Scripts and configuration files used by Genesis in the bootcd image
 
 %prep
-# noop  
+# noop
 
 %build
-# noop 
+# noop
 
 %install
 # add root's bash_profile
@@ -30,7 +30,7 @@ mkdir -p $RPM_BUILD_ROOT/root
 install -m 644 -T %{SOURCE0}   $RPM_BUILD_ROOT/root/.bash_profile.genesis_scripts
 
 # add some overrides we need
-mkdir -p $RPM_BUILD_ROOT/etc/sysconfig/network-scripts 
+mkdir -p $RPM_BUILD_ROOT/etc/sysconfig/network-scripts
 mkdir -p $RPM_BUILD_ROOT/etc/init
 mkdir -p $RPM_BUILD_ROOT/etc/init.d
 install -m 755 -T %{SOURCE1}   $RPM_BUILD_ROOT/etc/init.d/network-prep
@@ -45,18 +45,18 @@ mkdir -p $RPM_BUILD_ROOT/usr/bin/
 install -m 555 -T %{SOURCE4}   $RPM_BUILD_ROOT/usr/bin/genesis-bootloader
 
 %clean
-# noop 
+# noop
 
 %files
 %defattr(-, root, root)
 %config /etc/init.d/network-prep
-%config /etc/sysconfig/init.diff 
+%config /etc/sysconfig/init.diff
 %config /etc/init/tty.conf.override
 %config /root/.bash_profile.genesis_scripts
 /usr/bin/genesis-bootloader
 /root/login-shell
 
-%post 
+%post
 cat /root/.bash_profile.genesis_scripts >> /root/.bash_profile
 # TODO undo this hack
 cp  /etc/init/tty.conf.override /etc/init/tty.conf
@@ -92,5 +92,3 @@ chkconfig --add network-prep
 
 * Tue May 06 2014 Jeremy Johnstone <jeremy@tumblr.com> 0.1-2
 - new package built with tito
-
-

--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -24,7 +24,7 @@ EOF
 	    # explicitly bring up only one interface now to prevent
 	    # using lots of dhcp dynamic addresses
 	    # and avoid routing issues with multiple interface on same network
-	    [[ -z "$network_up" ]] && /sbin/dhclient -1 $int && network_up="$int"
+	    [[ -z "$network_up" ]] && /sbin/dhclient -1 -timeout 15 $int && network_up="$int"
 	done
 	;;
     *)  ;;

--- a/bootcd/rpms/genesis_scripts/src/root-bash_profile
+++ b/bootcd/rpms/genesis_scripts/src/root-bash_profile
@@ -4,5 +4,6 @@ GENESIS_MODE="$(grep -o -e 'GENESIS_MODE=[^ ]*' /proc/cmdline | cut -c14-)"
 if [[ ! -z $GENESIS_MODE ]] && [ ! -e "/var/run/bootloader-autorun.lock" ]
   then
     touch /var/run/bootloader-autorun.lock
-    /usr/bin/genesis-bootloader | tee /var/log/genesis-bootloader.log
+    # disable task execution prompting when doing initial target run
+    GENESIS_PROMPT_TIMEOUT=0  /usr/bin/genesis-bootloader | tee /var/log/genesis-bootloader.log
 fi

--- a/src/framework/genesis_framework.gemspec
+++ b/src/framework/genesis_framework.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email = 'opensourcesoftware@tumblr.com'
 
   gem.date = '2015-02-11'
-  gem.version = '0.6.1'
+  gem.version = '0.6.2'
   gem.add_dependency('genesis_promptcli', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('genesis_retryingfetcher', '~> 0.4', '>= 0.4.0')
   gem.add_dependency('collins_client', '~> 0.2', '>= 0.2.0')

--- a/src/framework/lib/genesisframework/tasks.rb
+++ b/src/framework/lib/genesisframework/tasks.rb
@@ -52,9 +52,12 @@ module Genesis
       def self.execute task_name
         puts "\n#{task_name}\n================================================="
 
-        if $stdin.isatty
-          # only prompt if there is a person on stdin
-          return true unless Genesis::PromptCLI.ask("Would you like to run this task?", 10, true)
+        prompt_timeout = ENV['GENESIS_PROMPT_TIMEOUT'] \
+          || Genesis::Framework::Utils.config_cache['task_prompt_timeout'] \
+          || 10
+        if prompt_timeout.to_i > 0
+          # only prompt if there is a resonable timeout
+          return true unless Genesis::PromptCLI.ask("Would you like to run this task?", prompt_timeout, true)
         end
 
         task = Genesis::Framework::Tasks.const_get(task_name)


### PR DESCRIPTION
https://jira.ewr01.tumblr.net/browse/GEN-43
This time we will just suppress prompting for unreasonable prompt is given
This eliminates trying to guess of a person typed the command or not,
plus we can now set the default prompt timeout value in the config file!

@Primer42 @byxorna @defect @maddalab 