### PR TITLE
undo iptables from base genesis image

### DIFF
--- a/bootcd/genesis.ks
+++ b/bootcd/genesis.ks
@@ -132,7 +132,7 @@ ls /lib/modules | while read kernel; do
 done
 
 # iptables packages are pulled in no matter what %packages says
-echo '>>>> disabling iptables and ip5tables service'
+echo '>>>> disabling iptables and ip6tables services'
 rm -f /etc/rc*.d/*ip{,6}tables
 
 echo '>>>> updating fstab'

--- a/bootcd/genesis.ks
+++ b/bootcd/genesis.ks
@@ -32,8 +32,8 @@ filesystem
 glibc
 initscripts
 iproute
-iptables-ipv6
-iptables
+-iptables-ipv6
+-iptables
 iputils
 kernel
 ncurses
@@ -131,6 +131,9 @@ ls /lib/modules | while read kernel; do
   /sbin/dracut -f "/boot/initramfs-${kernel}.img" "$kernel"
 done
 
+# iptables packages are pulled in no matter what %packages says
+echo '>>>> disabling iptables and ip5tables service'
+rm -f /etc/rc*.d/*ip{,6}tables
 
 echo '>>>> updating fstab'
 cat > /etc/fstab <<_EOF_


### PR DESCRIPTION
https://jira.ewr01.tumblr.net/browse/SYSSRE-3264
iptables is reported as breaking access to a booted node and since it isn't providing any protection we don't need it.
Bottom line is don't start it.
FYI, kickstart is unhappy with attempts to remove it because of package and selinux dependencies.

Tested on a virtual testenv node and real physical node too.
This is currently the genesis test ipxe image.

@Primer42 @byxorna @defect @maddalab rfr