### PR TITLE
Gem install bug fixes

### DIFF
--- a/src/framework/genesis_framework.gemspec
+++ b/src/framework/genesis_framework.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email = 'opensourcesoftware@tumblr.com'
 
   gem.date = '2015-02-11'
-  gem.version = '0.6.2'
+  gem.version = '0.6.3'
   gem.add_dependency('genesis_promptcli', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('genesis_retryingfetcher', '~> 0.4', '>= 0.4.0')
   gem.add_dependency('collins_client', '~> 0.2', '>= 0.2.0')

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -143,7 +143,7 @@ module Genesis
               begin
                 require gem
               rescue LoadError
-                puts "Could not load gem #{gem} automatically, please load it explicitly in the task"
+                puts "Could not load gem #{gem} automatically. Maybe the gem name differs from its load path? Please load it explicitly in the task"
               end
             }
           else

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -124,7 +124,9 @@ module Genesis
                 || Gem::Dependency.new(item).matching_specs.count == 0
             end
             if gems.size > 0    # make sure we still have something to do
-              Kernel.system('gem', 'install', '--no-ri', '--no-rdoc', *gems)
+              options = ['--no-ri', '--no-rdoc', config.fetch(:gems_source, '').split]
+              args = (options << gems).flatten
+              Kernel.system('gem', 'install', *args)
               if $?.exitstatus != 0
                 raise "gem install #{gems.join(' ')} exited with status: " \
                   + $?.exitstatus.to_s

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -154,7 +154,7 @@ module Genesis
               begin
                 requires.each {|r| require r }
               rescue LoadError
-                puts "Could not load gem #{gem} automatically. Maybe the gem name differs from its load path? Please specify the name to require, or load it explicitly in the task."
+                raise "Could not load gem #{gem} automatically. Maybe the gem name differs from its load path? Please specify the name to require."
               end
             }
           else

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -138,8 +138,14 @@ module Genesis
             # now need to clear out the Gem cache so we can load it
             Gem.clear_paths
 
-            # Now we require all the gems you asked to be installed
-            what.all? { |gem| require gem }
+            # Attempt to require loaded gems, print a message if we can't.
+            what.all? { |gem|
+              begin
+                require gem
+              rescue LoadError
+                puts "Could not load gem #{gem} automatically, please load it explicitly in the task"
+              end
+            }
           else
             raise 'Unknown install provider: ' + provider.to_s
           end

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -118,7 +118,7 @@ module Genesis
               if item.is_a?(Hash)
                 gems.merge! item
               else
-                gems[item] = []
+                gems[item] = [item]
               end
             }
 
@@ -152,11 +152,7 @@ module Genesis
             # Attempt to require loaded gems, print a message if we can't.
             gems.each { |gem, requires|
               begin
-                if requires.empty?
-                  require gem
-                else
-                  requires.each {|r| require r }
-                end
+                requires.each {|r| require r }
               rescue LoadError
                 puts "Could not load gem #{gem} automatically. Maybe the gem name differs from its load path? Please specify the name to require, or load it explicitly in the task."
               end

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -135,7 +135,7 @@ module Genesis
             end
 
             if install_gems.size > 0    # make sure we still have something to do
-              options = ['--no-ri', '--no-rdoc', config.fetch(:gems_source, '').split]
+              options = config.fetch(:gem_args, '').split
               args = (options << install_gems.keys).flatten
               Kernel.system('gem', 'install', *args)
               if $?.exitstatus != 0

--- a/tasks/DSL.md
+++ b/tasks/DSL.md
@@ -67,7 +67,16 @@ Example:
 * `install provider, *what`
 
 Uses either the **yum** provider or the **gem** provider to (possibly) install
-software.  Installing a **gem** also does a `require` of it in the Ruby task class.
+software.
+
+When using the **gem** provider genesis will also try to require the gems. If
+the name of your gem does not match what needs to be required, you can specify
+paths to require like this:
+```
+install :gem, 'gem1', 'gem2' => ['gem2/foo', 'gem2/bar']
+```
+This will install `gem1` and `gem2` and require `gem1`, `gem2/foo` and
+`gem2/bar`.
 
 Example:
 [TimedBurnin.rb](https://github.com/tumblr/genesis/blob/master/tasks/TimedBurnin.rb#L13)

--- a/testenv/bootbox/puppet/modules/genesis/templates/config.yaml.erb
+++ b/testenv/bootbox/puppet/modules/genesis/templates/config.yaml.erb
@@ -19,6 +19,7 @@
         :gpgcheck:  0
 :gem_files:
     "genesis_framework": http://<%= @genesis_ipaddress %>:8888/gem/genesis_framework
+:gem_args: &gem_args --no-ri --no-rdoc --clear-sources # Arguments to pass to gem install. Can include --source for internal repos
 :collins:
     :host: <%= @collins_url %>
 :ntp_server: <%= @ntp_server %>

--- a/testenv/bootbox/puppet/modules/genesis/templates/config.yaml.erb
+++ b/testenv/bootbox/puppet/modules/genesis/templates/config.yaml.erb
@@ -19,7 +19,7 @@
         :gpgcheck:  0
 :gem_files:
     "genesis_framework": http://<%= @genesis_ipaddress %>:8888/gem/genesis_framework
-:gem_args: &gem_args --no-ri --no-rdoc --clear-sources # Arguments to pass to gem install. Can include --source for internal repos
+:gem_args: &gem_args --no-ri --no-rdoc # Arguments to pass to gem install. Can include --source for internal repos
 :collins:
     :host: <%= @collins_url %>
 :ntp_server: <%= @ntp_server %>


### PR DESCRIPTION
This pull request fixes/changes two things:

1) When installing gems using the DSL, include the gem sources specified in the config. Right now we can only install gems coming from rubygems.

2) `install :gem` tries to automagically require the gems we just installed. However, the name of the gem and the name we need to require isn't always the same which makes the task fail. This changes it so that we print a message if we fail to require the gem, and lets the user require it in the task. I would like to nuke the autoloading completely, but i also don't want to break backwards compatibility :)

@roymarantz @maddalab @byxorna @Primer42