### PR TITLE
Add support for "pluggable" loggers

### DIFF
--- a/src/framework/genesis_framework.gemspec
+++ b/src/framework/genesis_framework.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email = 'opensourcesoftware@tumblr.com'
 
   gem.date = '2015-02-11'
-  gem.version = '0.6.2'
+  gem.version = '0.6.4'
   gem.add_dependency('genesis_promptcli', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('genesis_retryingfetcher', '~> 0.4', '>= 0.4.0')
   gem.add_dependency('collins_client', '~> 0.2', '>= 0.2.0')

--- a/src/framework/lib/genesisframework/utils.rb
+++ b/src/framework/lib/genesisframework/utils.rb
@@ -14,6 +14,7 @@ module Genesis
       @@config_cache = Hash.new
       @@collins_conn = nil
       @@facter = nil
+      @@loggers = nil
 
       # mimicking rail's cattr_accessor
       def self.config_cache
@@ -46,9 +47,19 @@ module Genesis
         puts logline
         Syslog.open("genesis", Syslog::LOG_PID, Syslog::LOG_USER) unless Syslog.opened?
         Syslog.log(Syslog::LOG_INFO, logline)
-        if self.facter['asset_tag']
-          self.collins.log! self.facter['asset_tag'], message
+
+        # Load external logging modules and send log to them
+        if @@loggers.nil?
+          @@loggers = self.config_cache[:loggers].map {|logger|
+            begin
+              require "logging/#{logger.downcase}"
+              Logging.const_get(logger.to_sym)
+            rescue LoadError
+              puts "Could not load logger #{logger}"
+            end
+          }.compact
         end
+        @@loggers.each {|logger| logger.log logline}
       end
     end
   end

--- a/src/framework/lib/genesisframework/utils.rb
+++ b/src/framework/lib/genesisframework/utils.rb
@@ -1,4 +1,3 @@
-require 'syslog'
 require 'collins_client'
 require 'facter'
 
@@ -45,8 +44,6 @@ module Genesis
       def self.log subsystem, message
         logline = subsystem.to_s + " :: " + message
         puts logline
-        Syslog.open("genesis", Syslog::LOG_PID, Syslog::LOG_USER) unless Syslog.opened?
-        Syslog.log(Syslog::LOG_INFO, logline)
 
         # Load external logging modules and send log to them
         if @@loggers.nil?

--- a/tasks/modules/logging/collins.rb
+++ b/tasks/modules/logging/collins.rb
@@ -10,8 +10,8 @@ module Logging
     end
 
     def self.log message
-      if self.facter['asset_tag']
-        collins.log! 'tumblrtag301', message
+      if facter['asset_tag']
+        collins.log! facter['asset_tag'], message
       end
     end
   end

--- a/tasks/modules/logging/collins.rb
+++ b/tasks/modules/logging/collins.rb
@@ -1,0 +1,18 @@
+module Logging
+  module Collins
+
+    def self.collins
+      Genesis::Framework::Utils.collins
+    end
+
+    def self.facter
+      Genesis::Framework::Utils.facter
+    end
+
+    def self.log message
+      if self.facter['asset_tag']
+        collins.log! 'tumblrtag301', message
+      end
+    end
+  end
+end

--- a/tasks/modules/logging/syslog.rb
+++ b/tasks/modules/logging/syslog.rb
@@ -1,0 +1,10 @@
+require 'syslog'
+
+module Logging
+  module Syslog
+    def self.log message
+      Syslog.open("genesis", Syslog::LOG_PID, Syslog::LOG_USER) unless Syslog.opened?
+      Syslog.log(Syslog::LOG_INFO, message)
+    end
+  end
+end

--- a/tasks/modules/logging/syslog.rb
+++ b/tasks/modules/logging/syslog.rb
@@ -3,8 +3,8 @@ require 'syslog'
 module Logging
   module Syslog
     def self.log message
-      Syslog.open("genesis", Syslog::LOG_PID, Syslog::LOG_USER) unless Syslog.opened?
-      Syslog.log(Syslog::LOG_INFO, message)
+      ::Syslog.open("genesis", ::Syslog::LOG_PID, ::Syslog::LOG_USER) unless ::Syslog.opened?
+      ::Syslog.log(::Syslog::LOG_INFO, message)
     end
   end
 end

--- a/testenv/bootbox/puppet/modules/genesis/templates/config.yaml.erb
+++ b/testenv/bootbox/puppet/modules/genesis/templates/config.yaml.erb
@@ -22,3 +22,5 @@
 :collins:
     :host: <%= @collins_url %>
 :ntp_server: <%= @ntp_server %>
+:loggers:
+  - Collins


### PR DESCRIPTION
To support more logging destinations than collins, this adds a `loggers` config key which is used to load code from `tasks/modules/loggers`. The goal is to have a way of adding logging to various external destinations (elasticsearch for instance) without having to build them all in to the gem.

By default, tasks will log to stdout and syslog. Users can then specify logging classes in `tasks/modules/logging` to load and the log line will be sent using those as well.

@roymarantz @Primer42 @byxorna 