### PR TITLE
log stderr when genesis bootloader starts up

### DIFF
--- a/bootcd/rpms/genesis_scripts/src/root-bash_profile
+++ b/bootcd/rpms/genesis_scripts/src/root-bash_profile
@@ -5,5 +5,5 @@ if [[ ! -z $GENESIS_MODE ]] && [ ! -e "/var/run/bootloader-autorun.lock" ]
   then
     touch /var/run/bootloader-autorun.lock
     # disable task execution prompting when doing initial target run
-    GENESIS_PROMPT_TIMEOUT=0  /usr/bin/genesis-bootloader | tee /var/log/genesis-bootloader.log
+    GENESIS_PROMPT_TIMEOUT=0  /usr/bin/genesis-bootloader 2>&1 | tee /var/log/genesis-bootloader.log
 fi


### PR DESCRIPTION
@roymarantz @maddalab @Primer42  This fixes some logging in Genesis to show stderr when launching the bootloader.