### PR TITLE
Update ruby to 2.2

### DIFF
--- a/bootcd/create-image.sh
+++ b/bootcd/create-image.sh
@@ -50,6 +50,10 @@ pid=$!
 
 echo '### creating livecd'
 livecd-creator -c genesis.ks -f genesis -t "$tmpdir/live/" --cache="$tmpdir/livecache/" -v
+if [[ $? != 0 ]] ; then
+  echo "Error creating livecd image"
+  exit 1
+fi
 
 echo '### cleanup local rpm repo'
 kill $pid
@@ -57,7 +61,7 @@ unset pid
 rm -rf $REPO
 
 echo '### cleanup unused directories'
-rm -rf base dell epel it local ruby193 tftpboot updates fastbugs security
+rm -rf base epel local tftpboot updates fastbugs security
 
 echo '### create genesis.iso'
 livecd-iso-to-pxeboot genesis.iso

--- a/bootcd/rpms/genesis_scripts/genesis_scripts.spec
+++ b/bootcd/rpms/genesis_scripts/genesis_scripts.spec
@@ -1,5 +1,5 @@
 Name:           genesis_scripts
-Version:        0.7
+Version:        0.8
 Release:        1%{?dist}
 License:        Apache License, 2.0
 URL:            http://tumblr.github.io/genesis

--- a/bootcd/rpms/genesis_scripts/src/root-bash_profile
+++ b/bootcd/rpms/genesis_scripts/src/root-bash_profile
@@ -1,6 +1,11 @@
 
 GENESIS_MODE="$(grep -o -e 'GENESIS_MODE=[^ ]*' /proc/cmdline | cut -c14-)"
 
+# setup the ruby environment we need
+source /etc/profile.d/rvm.sh
+rvm list
+ruby --version
+
 if [[ ! -z $GENESIS_MODE ]] && [ ! -e "/var/run/bootloader-autorun.lock" ]
   then
     touch /var/run/bootloader-autorun.lock


### PR DESCRIPTION
@roymarantz @maddalab @Primer42 This guts that hacked up ruby rpm from the image and replaces it with a more modern, easily updatable version installed via RVM. This is in order to solve gem installation failures (see https://gist.github.com/luislavena/f064211759ee0f806c88#) with gem 2.2.2. Ive also cleaned up some cruft.