### PR TITLE
Fix logging so that it shows the task name

### DIFF
--- a/src/framework/genesis_framework.gemspec
+++ b/src/framework/genesis_framework.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |gem|
   gem.authors = ["Jeremy Johnstone", 'Roy Marantz', 'Gabe Conradi']
   gem.email = 'opensourcesoftware@tumblr.com'
 
-  gem.date = '2015-07-13'
-  gem.version = '0.6.4'
+  gem.date = '2015-10-15'
+  gem.version = '0.6.5'
   gem.add_dependency('genesis_promptcli', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('genesis_retryingfetcher', '~> 0.4', '>= 0.4.0')
   gem.add_dependency('collins_client', '~> 0.2', '>= 0.2.0')

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -98,7 +98,8 @@ module Genesis
         end
 
         def log message
-          Genesis::Framework::Utils.log(self.class.name, message)
+          task = self.ancestors.first.to_s.split('::').last
+          Genesis::Framework::Utils.log(task, message)
         end
 
         def prompt message, seconds=15, default=false

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -1,5 +1,3 @@
-require 'collins_client'
-require 'syslog'
 require 'retryingfetcher'
 require 'promptcli'
 require 'facter'

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -169,7 +169,8 @@ module Genesis
         end
 
         def tmp_path filename
-          Genesis::Framework::Utils.tmp_path(filename, self.class.name)
+          task = self.ancestors.first.to_s.split('::').last
+          Genesis::Framework::Utils.tmp_path(filename, task)
         end
 
         #############################################################

--- a/src/framework/lib/genesisframework/task.rb
+++ b/src/framework/lib/genesisframework/task.rb
@@ -96,8 +96,7 @@ module Genesis
         end
 
         def log message
-          task = self.ancestors.first.to_s.split('::').last
-          Genesis::Framework::Utils.log(task, message)
+          Genesis::Framework::Utils.log(task_name, message)
         end
 
         def prompt message, seconds=15, default=false
@@ -167,8 +166,11 @@ module Genesis
         end
 
         def tmp_path filename
-          task = self.ancestors.first.to_s.split('::').last
-          Genesis::Framework::Utils.tmp_path(filename, task)
+          Genesis::Framework::Utils.tmp_path(filename, task_name)
+        end
+
+        def task_name
+          self.ancestors.first.to_s.split('::').last
         end
 
         #############################################################


### PR DESCRIPTION
Right now, when the framework writes a log it isn't able to determine the name of the task that sent the message, making log messages look like for example like `Class :: Wrote system time to hardware clock`.

This has annoyed me for a while, and I was poking around genesis anyway so I thought I'd take a stab at fixing it.

This change makes the `log` DSL method look at the first ancestor (which is the task class) and grab the name from that. I thought `Genesis::Framework::Task::SetupNTP` was a bit of a mouthful, so I'm only grabbing the last part of it. I'm open for suggestions though. 

The end result with the same example looks like this: `SetupNTP :: Wrote system time to hardware clock`.

@roymarantz @Primer42 @byxorna 