### PR TITLE
dockerize the build of genesis live CDs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+bootcd/output
+bootcd/rpms/*rpm
+**.rpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:6
+MAINTAINER Gabe Conradi <gabe.conradi@gmail.com>
+
+ENV OUTPUT_DIR /output
+ENV GENESIS_DIR /genesis
+VOLUME /output
+
+# needed for livecd-creator
+RUN curl -o epel.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm && \
+  rpm -ivh epel.rpm && \
+  rm epel.rpm
+
+RUN yum install -y livecd-tools createrepo curl unzip rpm-build && \
+  yum clean all
+
+
+COPY . /genesis
+WORKDIR /genesis
+
+# perform the build of the image at runtime
+CMD ["/genesis/docker-entrypoint.sh"]

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -10,7 +10,7 @@ RUN curl -o epel.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-6
   rpm -ivh epel.rpm && \
   rm epel.rpm
 
-RUN yum install -y livecd-tools createrepo curl unzip rpm-build && \
+RUN yum install -y livecd-tools createrepo curl rpm-build && \
   yum clean all
 
 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,0 +1,16 @@
+FROM centos:7
+MAINTAINER Gabe Conradi <gabe.conradi@gmail.com>
+
+ENV OUTPUT_DIR /output
+ENV GENESIS_DIR /genesis
+ENV KICKSTART genesis-sl7.ks
+VOLUME /output
+
+RUN yum install -y livecd-tools createrepo rpm-build && \
+  yum clean all
+
+COPY . /genesis
+WORKDIR /genesis
+
+# perform the build of the image at runtime
+CMD ["/genesis/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ have docker running on your machine and just want to build the latest images:
 To build a custom image, if you have tweaked something about genesis, you can present build a custom builder image:
 
 ```
-# docker build -t genesis-builder .
+# docker build -f Dockerfile.centos6 -t genesis-builder .
 # docker run --privileged=true -v $(pwd)/output:/output genesis-builder
 # ls output
 ```

--- a/README.md
+++ b/README.md
@@ -80,6 +80,26 @@ framework, new tasks, etc.
 More information about the test environment and setting it up can be found in
 [testenv/README.md](https://github.com/tumblr/genesis/blob/master/testenv/README.md).
 
+## Building an Image
+
+To make it easy to get started with genesis, we have included a `Dockerfile` that will allow
+you to compile a bootable live image without needing a lot of client side configuration. If you
+have docker running on your machine and just want to build the latest images:
+
+```
+# mkdir output
+# docker run --privileged=true -v $(pwd)/output:/output tumblr/genesis-builder
+# ls output
+```
+
+To build a custom image, if you have tweaked something about genesis, you can present build a custom builder image:
+
+```
+# docker build -t genesis-builder .
+# docker run --privileged=true -v $(pwd)/output:/output genesis-builder
+# ls output
+```
+
 ## Contact
 Please feel free to open issues on GitHub for any feedback or problems you might
 run in to. We also actively encourage pull requests. Please also make

--- a/bootcd/README.md
+++ b/bootcd/README.md
@@ -3,19 +3,35 @@ This directory contains sources for building the image that is booted to run gen
 tasks. You can use the [test environment](https://github.com/tumblr/genesis/blob/master/testenv/README.md) to build the genesis image, or use a SL6
 installation. The instructions below assume you are using the test environment.
 
-## Pre-requisites:
+## The easy (docker) way:
+
+You probably just want to build a genesis live image with no hassle. Just get docker running on your host, and run:
+
+```
+$ docker run -v /tmp:/output tumblr/genesis-builder
+$ ls /tmp
+genesis.iso
+genesis-initrd.img
+genesis-vmlinuz
+```
+
+Now, you just need to copy the bootable `vmlinuz` and `initrd` somewhere where your PXE/iPXE server can fetch them over HTTP.
+
+## The super hard way:
+
+### Pre-requisites:
 
 Pre-requisites are installed when using the test environment and include
 
 - livecd-tools and createrepo RPMs installed
 - python and SimpleHTTPServer module
 
-## Building the Genesis Scripts RPM:
+### Building the Genesis Scripts RPM:
 
 The Genesis scripts rpm includes scripts and configuration files used by Genesis in the bootcd image
 
  - Bring up the testenv and ssh into the bootbox (vagrant ssh) or ensure all of the [pre requisites](#pre-requisites) are installed correctly
- - Build the RPMs using rpmbuild and mock:
+ - Build the RPMs using rpmbuild:
 
 ```cd /genesis/bootcd/rpms/genesis_scripts```
 
@@ -25,19 +41,14 @@ The Genesis scripts rpm includes scripts and configuration files used by Genesis
 
  - Build the rpm (ensure the src rpm version is correct, when copy-pasting from here, it is likely to be incorrect)
 
-```mock -r epel-6-x86_64 --rebuild genesis_scripts-0.8-1.el6.src.rpm```
+```rpmbuild --rebuild --rebuild genesis_scripts-0.8-1.el6.src.rpm```
 
-If trying to rebuild gives you a file or directory not found error, clear mock
-data.
-
-```mock --scrub=all```
-
- - Resulting RPM can be found in /var/lib/mock/epel-6-x86/result
+ - Resulting RPM can be found in your RPM build path (/root/rpmbuild/RPMS/noarch/ if building as root with no rpmconfig)
  - Copy the RPM into [bootcd/rpms](https://github.com/tumblr/genesis/tree/master/bootcd/rpms)
-   - ```cp /var/lib/mock/epel-6-x86_64/result/genesis_scripts-0.8-1.el6.noarch.rpm ../```
+   - ```cp /root/rpmbuild/RPMS/noarch//genesis_scripts-0.8-1.el6.noarch.rpm ../```
    - The ```create-image.sh``` script will look for the RPM in this location
 
-## Building the boot image:
+### Building the boot image:
  - Bring up the testenv and ssh into the bootbox (vagrant ssh) or ensure all of the [pre requisites](#pre-requisites) are installed correctly
  - Build the ``genesis_scripts`` rpm, and copy it to ``/genesis/bootcd/rpms``. [See these docs for instructions.](#building-the-genesis-scripts-rpm)
  - Build the genesis gems found in `/genesis/src`. Do not move or install them. [See these instructions for how to build the gems.](https://github.com/tumblr/genesis/blob/master/src/README.md)
@@ -45,8 +56,10 @@ data.
  - ```sudo ./create-image.sh```
  - The ```create-image``` script will create the initrd and kernel in ```/genesis/bootcd/output```
 
-## Deploying the boot image:
+### Deploying the boot image:
  - Copy the files from the output to where PXEBoot is expecting it, this is typically your file server.
+
+# Notes
 
 ## Tmpfs Root for Production
 

--- a/bootcd/create-image.sh
+++ b/bootcd/create-image.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 REPO=repo
+export OUTPUT_DIR="${OUTPUT_DIR:-/output}"
 
-set -e
+set -ex
 
 if [[ $EUID -ne 0 ]]; then
   echo "This script must be run as root" 
@@ -14,6 +15,10 @@ for cmd in createrepo livecd-creator livecd-iso-to-pxeboot; do
     exit 1
   fi
 done
+if [[ ! -d $OUTPUT_DIR ]] ; then
+  echo "OUTPUT_DIR must be a directory"
+  exit 1
+fi
 
 cleanup() {
     [[ -n "$pid" ]] && kill $pid
@@ -66,12 +71,11 @@ rm -rf base epel local tftpboot updates fastbugs security
 echo '### create genesis.iso'
 livecd-iso-to-pxeboot genesis.iso
 
-mkdir -p output
-mv tftpboot/initrd0.img output/genesis-initrd.img
-mv tftpboot/vmlinuz0 output/genesis-vmlinuz
-chmod 644 output/genesis-vmlinuz
-mv genesis.iso output/
+mv tftpboot/initrd0.img $OUTPUT_DIR/genesis-initrd.img
+mv tftpboot/vmlinuz0 $OUTPUT_DIR/genesis-vmlinuz
+chmod 644 $OUTPUT_DIR/genesis-vmlinuz
+mv genesis.iso $OUTPUT_DIR/
 rm -rf tftpboot
 
-printf "### $0 completed successfully results in ./output/"
-ls -l output
+printf "### $0 completed successfully results in $OUTPUT_DIR"
+ls -l $OUTPUT_DIR

--- a/bootcd/genesis.ks
+++ b/bootcd/genesis.ks
@@ -108,6 +108,13 @@ _EOF_
 echo '>>>> setting hostname'
 sed -i -e 's/HOSTNAME=.*/HOSTNAME=genesis/' /etc/sysconfig/network
 
+echo '>>>> setting /etc/resolv.conf to point to public resolvers'
+# this is necessary to resolve get.rvm.io and friends in %post
+cat >/etc/resolv.conf <<"__EOF__"
+# you probably want to override this file with your own resolvers
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+__EOF__
 
 echo '>>>> rewriting /etc/motd'
 cat > /etc/motd <<"__EOF__"
@@ -158,16 +165,6 @@ EOL
 ##rm -f /etc/sysconfig/selinux
 ##ln -s ../selinux/config /etc/sysconfig/selinux
 
-
-# ruby now installed above
-# build latest stable ruby
-#mkdir /tmp/ruby
-#cd /tmp/ruby
-#curl -k https://ftp.ruby-lang.org/pub/ruby/stable-snapshot.tar.gz | tar -xzf -
-#cd stable-snapshot
-#./configure
-#make
-#make install
 
 # Install RVM
 echo '>>>> setting up rvm'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+export GENESIS_DIR="${GENESIR_DIR:-/genesis}"
+export OUTPUT_DIR="${OUTPUT_DIR:-/output}"
+
+set -ex
+echo "Performing build of Genesis Framework"
+cd $GENESIS_DIR
+
+echo "===> Building Genesis Scripts RPM"
+pushd $GENESIS_DIR/bootcd/rpms/genesis_scripts
+rpmbuild --define '_tmppath /tmp' --define '_sourcedir src' --define '_srcrpmdir .' --nodeps -bs genesis_scripts.spec
+rpmbuild --rebuild genesis_scripts-*.src.rpm
+cp /root/rpmbuild/RPMS/noarch/genesis_scripts-*.noarch.rpm $GENESIS_DIR/bootcd/rpms/
+popd
+echo ":: Built RPM:"
+ls -la $GENESIS_DIR/bootcd/rpms/
+
+echo "===> Building Genesis Image"
+cd bootcd
+# this is necessary to avoid devicemapper syncronization raceconditions creating
+# devices in livecdcreator. Just use the old fallback logic when run in a container:
+# https://www.redhat.com/archives/lvm-devel/2012-November/msg00069.html
+export DM_DISABLE_UDEV=1
+./create-image.sh


### PR DESCRIPTION
@tumblr/systems @roymarantz @defect @Primer42 @maddalab This will make building genesis live CDs easier, by dockerizing the dependencies. 