### PR TITLE
Genesis config access by string keys

### DIFF
--- a/bootcd/rpms/genesis_scripts/src/genesis-bootloader
+++ b/bootcd/rpms/genesis_scripts/src/genesis-bootloader
@@ -41,7 +41,8 @@ genesis_conf = nil
 # don't put in a block since any raise will look like it is coming from the get
 data = Genesis::RetryingFetcher.get(GENESIS_CONF_URL)
 begin
-  genesis_config = YAML::load(data)
+  # symbolize keys for loaded file
+  genesis_config = YAML.load(data).inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
 rescue => e
   if STDIN.tty?
     puts "GENESIS_CONF_URL has invalid yaml: #{e.message}"
@@ -75,8 +76,8 @@ puts '---', ''
 
 # fetch stage2
 loop do
-  Genesis::RetryingFetcher.get(GENESIS_STAGE2_URL) do |data|
-    File.open(GENESIS_STAGE2_SCRIPT, 'w', 0555) { |file| file.puts data }
+  Genesis::RetryingFetcher.get(GENESIS_STAGE2_URL) do |d|
+    File.open(GENESIS_STAGE2_SCRIPT, 'w', 0555) { |file| file.puts d }
   end
 
   # verify stage 2
@@ -85,7 +86,7 @@ loop do
   break if syntax_valid
 
   puts ''
-  try_fetching = Genesis::PromptCLI.ask "Genesis Stage 2 is corrupt. Would you like to retry?" 
+  try_fetching = Genesis::PromptCLI.ask "Genesis Stage 2 is corrupt. Would you like to retry?"
   unless  try_fetching
     raise RuntimeError, msg + "Genesis Stage 2 is corrupt. Execution halted!"
   end

--- a/bootcd/rpms/genesis_scripts/src/genesis-bootloader
+++ b/bootcd/rpms/genesis_scripts/src/genesis-bootloader
@@ -41,8 +41,8 @@ genesis_conf = nil
 # don't put in a block since any raise will look like it is coming from the get
 data = Genesis::RetryingFetcher.get(GENESIS_CONF_URL)
 begin
-  # symbolize keys for loaded file
-  genesis_config = YAML.load(data).inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+  # ensure loaded config has stringified keys, for consistent access
+  genesis_config = YAML.load(data).inject({}){|memo,(k,v)| memo[k.to_s] = v; memo}
 rescue => e
   if STDIN.tty?
     puts "GENESIS_CONF_URL has invalid yaml: #{e.message}"
@@ -52,16 +52,16 @@ raise "ERROR: #{GENESIS_CONF_URL} did not contain valid yaml or was empty" \
   if (genesis_config.nil? || genesis_config.empty?)
 
 # allow GENESIS_ROOT to be overridden from config
-GENESIS_ROOT = genesis_config.fetch(:root, '/var/run/genesis')
+GENESIS_ROOT = genesis_config.fetch('root', '/var/run/genesis')
 puts 'Genesis root is: %s' % [GENESIS_ROOT]
 
-GENESIS_CONFIG_FILE = genesis_config.fetch(:config_file,
+GENESIS_CONFIG_FILE = genesis_config.fetch('config_file',
   File.join(GENESIS_ROOT, 'config.yaml'))
 
-GENESIS_STAGE2_URL = genesis_config.fetch(:stage2_url,
+GENESIS_STAGE2_URL = genesis_config.fetch('stage2_url',
   File.join(File.dirname(GENESIS_CONF_URL), 'stage2'))
-GENESIS_STAGE2_SCRIPT =  genesis_config.fetch(:stage2_file,
-  File.join(GENESIS_ROOT, "stage2"))
+GENESIS_STAGE2_SCRIPT =  genesis_config.fetch('stage2_file',
+  File.join(GENESIS_ROOT, 'stage2'))
 
 # Create our basic directory tree
 Dir.mkdir(GENESIS_ROOT, 0755) unless File.directory? GENESIS_ROOT

--- a/src/framework/lib/genesisframework/utils.rb
+++ b/src/framework/lib/genesisframework/utils.rb
@@ -21,7 +21,8 @@ module Genesis
       end
 
       def self.config_cache= (obj)
-        @@config_cache = obj
+        # cull all keys to strings to ensure consistent access
+        @@config_cache = obj.inject({}){|memo,(k,v)| memo[k.to_s] = v; memo}
       end
 
       def self.collins
@@ -47,14 +48,14 @@ module Genesis
 
         # Load external logging modules and send log to them
         if @@loggers.nil?
-          @@loggers = self.config_cache[:loggers].map {|logger|
+          @@loggers = self.config_cache['loggers'].map do |logger|
             begin
               require "logging/#{logger.downcase}"
               Logging.const_get(logger.to_sym)
             rescue LoadError
               puts "Could not load logger #{logger}"
             end
-          }.compact
+          end.compact
         end
         @@loggers.each {|logger| logger.log logline}
       end


### PR DESCRIPTION
@Primer42 @roymarantz @schallert @defect Genesis bootloader looks for symbolized keys in the genesis configuration, whereas other parts of the framework look for string keys. Ive forced culling all keys in genesis to strings to ensure the end user isn't responsible for knowing which keys need to be strings and which symbols (as determining this experimentally is extremely painful).
