### PR TITLE
base image improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 bootcd/output
 bootcd/rpms/*rpm
 **.rpm
+output/*

--- a/bootcd/genesis.ks
+++ b/bootcd/genesis.ks
@@ -54,6 +54,7 @@ tmux
 traceroute
 util-linux-ng
 vim-minimal
+bind-utils
 yum
 # needed for rvm
 which
@@ -68,6 +69,7 @@ glibc-headers
 
 %post
 set -e
+set -x
 repo_base_url="http://ftp.scientificlinux.org/linux/scientific/6x/x86_64"
 # Apply Genesis Live OS customizations
 echo '*****************************************'
@@ -104,6 +106,8 @@ tmpfs     /var/tmp        tmpfs   mode=1777         0
 tmpfs     /var/cache/yum  tmpfs   mode=1777         0
 _EOF_
 
+# make sure any console can get a login. sigh...
+rm /etc/securetty
 
 echo '>>>> setting hostname'
 sed -i -e 's/HOSTNAME=.*/HOSTNAME=genesis/' /etc/sysconfig/network
@@ -203,6 +207,7 @@ su - -c 'source /etc/profile.d/rvm.sh && bundle install --system --gemfile /root
 echo '>>>> installing basic genesis framework gems'
 bash -c "source /etc/profile.d/rvm.sh && gem install genesis_retryingfetcher"
 bash -c "source /etc/profile.d/rvm.sh && gem install genesis_promptcli"
+bash -c "source /etc/profile.d/rvm.sh && gem install genesis_framework"
 bash -c "source /etc/profile.d/rvm.sh && gem list"
 
 #echo '>>>> cleanup now unneeds RPMs to make image smaller'

--- a/bootcd/rpms/genesis_scripts/genesis_scripts.spec
+++ b/bootcd/rpms/genesis_scripts/genesis_scripts.spec
@@ -11,6 +11,8 @@ Source2:        src/sysconfig-init.diff
 Source3:        src/tty.conf.override
 Source4:        src/genesis-bootloader
 Source5:        src/login-shell
+Source6:        src/ttyS0.conf
+Source7:        src/ttyS1.conf
 Summary:        Scripts used by Genesis in the bootcd image
 Group:          System Environment/Base
 Requires:       initscripts rootfiles patch
@@ -40,6 +42,9 @@ install -m 644 -T %{SOURCE3}   $RPM_BUILD_ROOT/etc/init/tty.conf.override
 # add helper for agetty
 install -m 555 -T %{SOURCE5}   $RPM_BUILD_ROOT/root/login-shell
 
+install -m 644 -T %{SOURCE6}   $RPM_BUILD_ROOT/etc/init/ttyS0.conf
+install -m 644 -T %{SOURCE7}   $RPM_BUILD_ROOT/etc/init/ttyS1.conf
+
 # add the bootloader
 mkdir -p $RPM_BUILD_ROOT/usr/bin/
 install -m 555 -T %{SOURCE4}   $RPM_BUILD_ROOT/usr/bin/genesis-bootloader
@@ -52,6 +57,8 @@ install -m 555 -T %{SOURCE4}   $RPM_BUILD_ROOT/usr/bin/genesis-bootloader
 %config /etc/init.d/network-prep
 %config /etc/sysconfig/init.diff
 %config /etc/init/tty.conf.override
+%config /etc/init/ttyS0.conf
+%config /etc/init/ttyS1.conf
 %config /root/.bash_profile.genesis_scripts
 /usr/bin/genesis-bootloader
 /root/login-shell

--- a/bootcd/rpms/genesis_scripts/src/root-bash_profile
+++ b/bootcd/rpms/genesis_scripts/src/root-bash_profile
@@ -10,5 +10,5 @@ if [[ ! -z $GENESIS_MODE ]] && [ ! -e "/var/run/bootloader-autorun.lock" ]
   then
     touch /var/run/bootloader-autorun.lock
     # disable task execution prompting when doing initial target run
-    GENESIS_PROMPT_TIMEOUT=0  /usr/bin/genesis-bootloader 2>&1 | tee /var/log/genesis-bootloader.log
+    GENESIS_PROMPT_TIMEOUT=0  /usr/bin/genesis-bootloader 2>&1 | tee -a /var/log/genesis-bootloader.log | tee /dev/console
 fi

--- a/bootcd/rpms/genesis_scripts/src/ttyS0.conf
+++ b/bootcd/rpms/genesis_scripts/src/ttyS0.conf
@@ -6,4 +6,4 @@ start on runlevel [345]
 stop on runlevel [S016]
 
 respawn
-exec /sbin/getty -L 115200 ttyS0 vt102
+exec /sbin/agetty -8 -n 115200 /dev/ttyS0

--- a/bootcd/rpms/genesis_scripts/src/ttyS0.conf
+++ b/bootcd/rpms/genesis_scripts/src/ttyS0.conf
@@ -1,0 +1,9 @@
+# ttyS0 - getty
+#
+# This service maintains a getty on ttyS0 from the point the system is
+# started until it is shut down again.
+start on runlevel [345]
+stop on runlevel [S016]
+
+respawn
+exec /sbin/getty -L 115200 ttyS0 vt102

--- a/bootcd/rpms/genesis_scripts/src/ttyS1.conf
+++ b/bootcd/rpms/genesis_scripts/src/ttyS1.conf
@@ -6,4 +6,4 @@ start on runlevel [345]
 stop on runlevel [S016]
 
 respawn
-exec /sbin/getty -L 115200 ttyS1 vt102
+exec /sbin/agetty -8 -n 115200 /dev/ttyS1

--- a/bootcd/rpms/genesis_scripts/src/ttyS1.conf
+++ b/bootcd/rpms/genesis_scripts/src/ttyS1.conf
@@ -1,0 +1,9 @@
+# ttyS1 - getty
+#
+# This service maintains a getty on ttyS1 from the point the system is
+# started until it is shut down again.
+start on runlevel [345]
+stop on runlevel [S016]
+
+respawn
+exec /sbin/getty -L 115200 ttyS1 vt102


### PR DESCRIPTION
Improve the base genesis image some. Adds dns utilities to the base image (v important for debugging), and launches serial consoles. Also, it looks like someone forgot to install the genesis_framework in the base image, so do that too...

@Primer42 @defect @roymarantz 
