### PR TITLE
fixes to support release with binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 bootcd/output
 bootcd/rpms/*rpm
 **.rpm
+output/*

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Gemfile.lock
 # built rpms
 **/genesis_scripts-*.noarch.rpm
 **/genesis_scripts-*.src.rpm
+
+output

--- a/bootcd/README.md
+++ b/bootcd/README.md
@@ -3,17 +3,23 @@ This directory contains sources for building the image that is booted to run gen
 tasks. You can use the [test environment](https://github.com/tumblr/genesis/blob/master/testenv/README.md) to build the genesis image, or use a SL6
 installation. The instructions below assume you are using the test environment.
 
+## The easiest way:
+
+Get the prebuilt binaries from the github release :-)
+
 ## The easy (docker) way:
 
 You probably just want to build a genesis live image with no hassle. Just get docker running on your host, and run:
 
 ```
-$ docker run -v /tmp:/output tumblr/genesis-builder
-$ ls /tmp
+$ docker run -v $PWD/output:/output tumblr/genesis-builder
+$ ls $PWD/output
 genesis.iso
 genesis-initrd.img
 genesis-vmlinuz
 ```
+
+NOTE: if you get an error about not being able to do a loopback mount add ```--privileged```
 
 Now, you just need to copy the bootable `vmlinuz` and `initrd` somewhere where your PXE/iPXE server can fetch them over HTTP.
 

--- a/bootcd/genesis.ks
+++ b/bootcd/genesis.ks
@@ -203,6 +203,7 @@ su - -c 'source /etc/profile.d/rvm.sh && bundle install --system --gemfile /root
 echo '>>>> installing basic genesis framework gems'
 bash -c "source /etc/profile.d/rvm.sh && gem install genesis_retryingfetcher"
 bash -c "source /etc/profile.d/rvm.sh && gem install genesis_promptcli"
+bash -c "source /etc/profile.d/rvm.sh && gem install genesis_framework"
 bash -c "source /etc/profile.d/rvm.sh && gem list"
 
 #echo '>>>> cleanup now unneeds RPMs to make image smaller'


### PR DESCRIPTION
Some minor changes in preparation for doing a release that includes binary images.  The intent is to do a 1.0.0 release and attach genesis-initrd.img and genesis-vmlinuz to it to make the barrier to entry for getting started with genesis lower.