### PR TITLE
fix system time

### DIFF
--- a/bootcd/genesis.ks
+++ b/bootcd/genesis.ks
@@ -21,6 +21,7 @@ attr
 authconfig
 basesystem
 bash
+bind-utils
 chkconfig
 coreutils
 cpio
@@ -37,6 +38,7 @@ iproute
 iputils
 kernel
 ncurses
+ntpdate
 openssh-server
 openssh-clients
 passwd

--- a/bootcd/rpms/genesis_scripts/genesis_scripts.spec
+++ b/bootcd/rpms/genesis_scripts/genesis_scripts.spec
@@ -1,5 +1,5 @@
 Name:           genesis_scripts
-Version:        0.8
+Version:        0.9
 Release:        1%{?dist}
 License:        Apache License, 2.0
 URL:            http://tumblr.github.io/genesis

--- a/bootcd/rpms/genesis_scripts/src/genesis-bootloader
+++ b/bootcd/rpms/genesis_scripts/src/genesis-bootloader
@@ -50,6 +50,15 @@ end
 raise "ERROR: #{GENESIS_CONF_URL} did not contain valid yaml or was empty" \
   if (genesis_config.nil? || genesis_config.empty?)
 
+# fix the system clock if possible to keep log entries more accurate
+# and prevent false cert expired verification problems
+ntp_server = genesis_config.fetch('ntp_server', nil)
+if ntp_server and File.executable?('/usr/sbin/ntpdate')
+  puts "Setting the system time from #{ntp_server.inspect}"
+  system('/usr/sbin/ntpdate', '-u', '-b', ntp_server) \
+    or puts "ERROR: failed to set system time ntpdate returned: #{$?.inspect}"
+end
+
 # allow GENESIS_ROOT to be overridden from config
 GENESIS_ROOT = genesis_config.fetch(:root, '/var/run/genesis')
 puts 'Genesis root is: %s' % [GENESIS_ROOT]
@@ -85,7 +94,7 @@ loop do
   break if syntax_valid
 
   puts ''
-  try_fetching = Genesis::PromptCLI.ask "Genesis Stage 2 is corrupt. Would you like to retry?" 
+  try_fetching = Genesis::PromptCLI.ask "Genesis Stage 2 is corrupt. Would you like to retry?"
   unless  try_fetching
     raise RuntimeError, msg + "Genesis Stage 2 is corrupt. Execution halted!"
   end


### PR DESCRIPTION
if the system time is (very) wrong then https cert validation falsely fails.  Also logs are hard to interpret.

I tested this out on a node by copying in the modified file and rerunning genesis-bootloader.

@Primer42 @defect @qx-xp @schallert @sushruta rfr