### PR TITLE
make dhcp timeout 40s instead of 15s

### DIFF
--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -24,7 +24,7 @@ EOF
 	    # explicitly bring up only one interface now to prevent
 	    # using lots of dhcp dynamic addresses
 	    # and avoid routing issues with multiple interface on same network
-	    [[ -z "$network_up" ]] && /sbin/dhclient -1 -timeout 15 $int && network_up="$int"
+	    [[ -z "$network_up" ]] && /sbin/dhclient -1 -timeout 40 $int && network_up="$int"
 	done
 	;;
     *)  ;;

--- a/bootcd/rpms/genesis_scripts/src/init.d-network-prep
+++ b/bootcd/rpms/genesis_scripts/src/init.d-network-prep
@@ -24,7 +24,7 @@ EOF
 	    # explicitly bring up only one interface now to prevent
 	    # using lots of dhcp dynamic addresses
 	    # and avoid routing issues with multiple interface on same network
-	    [[ -z "$network_up" ]] && /sbin/dhclient -1 -timeout 40 $int && network_up="$int"
+	    [[ -z "$network_up" ]] && /sbin/dhclient -1 -timeout 60 $int && network_up="$int"
 	done
 	;;
     *)  ;;


### PR DESCRIPTION
Some DHCP relay configurations make DHCP take a really long time to do its dance. Try to guard against this.

@roymarantz @schallert @Primer42 