### PR TITLE
Include dmidecode in the genesis base image

### DIFF
--- a/bootcd/genesis.ks.template
+++ b/bootcd/genesis.ks.template
@@ -28,6 +28,7 @@ cpio
 device-mapper
 device-mapper-event
 dhclient
+dmidecode
 e2fsprogs
 filesystem
 glibc


### PR DESCRIPTION
It's really useful for resolving a lot of facts, and facter caches the bad results if your fact doesn't super sanity check that dmidecode is installed and working.

I have rebuilt the base image, and seen that kickstart installs dmidecode

@tumblr/collins 