### PR TITLE
Add option to disable facter caching

### DIFF
--- a/src/framework/genesis_framework.gemspec
+++ b/src/framework/genesis_framework.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email = 'opensourcesoftware@tumblr.com'
 
   gem.date = '2016-01-13'
-  gem.version = '0.6.6'
+  gem.version = '0.6.7'
   gem.add_dependency('genesis_promptcli', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('genesis_retryingfetcher', '~> 0.4', '>= 0.4.0')
   gem.add_dependency('collins_client', '~> 0.2', '>= 0.2.0')

--- a/src/framework/lib/genesisframework/utils.rb
+++ b/src/framework/lib/genesisframework/utils.rb
@@ -34,7 +34,7 @@ module Genesis
       end
 
       def self.facter
-        if config_cache[:facter_cache] == false
+        if config_cache.fetch(:facter_cache, true)
           Facter.to_hash
         else
           if @@facter.nil?

--- a/src/framework/lib/genesisframework/utils.rb
+++ b/src/framework/lib/genesisframework/utils.rb
@@ -34,11 +34,15 @@ module Genesis
       end
 
       def self.facter
-        if @@facter.nil?
-          @@facter = Facter.to_hash
-        end
+        if config_cache[:facter_cache] == false
+          Facter.to_hash
+        else
+          if @@facter.nil?
+            @@facter = Facter.to_hash
+          end
 
-        @@facter
+          @@facter
+        end
       end
 
       def self.log subsystem, message

--- a/testenv/bootbox/puppet/modules/genesis/templates/config.yaml.erb
+++ b/testenv/bootbox/puppet/modules/genesis/templates/config.yaml.erb
@@ -25,3 +25,4 @@
 :ntp_server: <%= @ntp_server %>
 :loggers:
   - Collins
+:facter_cache: true # If true, genesis will cache the facts from facter for the whole run. Defaults to true.


### PR DESCRIPTION
The genesis framework currently caches the results of running facter. This becomes a bit of a problem if one of the facts change during a run. For instance, if we're running a target that updates the asset tag set in the SMBIOS this will not reflect in subsequent tasks since it has been cached.

This adds a configuration parameter to disable this cache and do a full facter lookup each time. This will obviously have a bit of a performance hit, but it's fairly small (at least in our genesis/facter setup). It defaults to false though, so existing configs should work the same way they did.

@Primer42 @roymarantz @qx-xp @gtorre 