### PR TITLE
Fix facter cache logic

### DIFF
--- a/src/framework/genesis_framework.gemspec
+++ b/src/framework/genesis_framework.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email = 'opensourcesoftware@tumblr.com'
 
   gem.date = '2016-01-13'
-  gem.version = '0.6.7'
+  gem.version = '0.6.8'
   gem.add_dependency('genesis_promptcli', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('genesis_retryingfetcher', '~> 0.4', '>= 0.4.0')
   gem.add_dependency('collins_client', '~> 0.2', '>= 0.2.0')

--- a/src/framework/lib/genesisframework/utils.rb
+++ b/src/framework/lib/genesisframework/utils.rb
@@ -35,13 +35,12 @@ module Genesis
 
       def self.facter
         if config_cache.fetch(:facter_cache, true)
-          Facter.to_hash
-        else
           if @@facter.nil?
             @@facter = Facter.to_hash
           end
-
           @@facter
+        else
+          Facter.to_hash
         end
       end
 


### PR DESCRIPTION
The `facter_cache` logic is doing the opposite of what it is supposed to do.

As described in https://github.com/tumblr/genesis/pull/63, it should use the cache when `facter_cache` is true, and disable the cache when `facter_cache` is false. The default is to enable the cache.

rfr @defect @roymarantz @gtorre 