### PR TITLE
Add task to disable CPU frequency scaling

### DIFF
--- a/src/framework/genesis_framework.gemspec
+++ b/src/framework/genesis_framework.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email = 'opensourcesoftware@tumblr.com'
 
   gem.date = '2016-01-13'
-  gem.version = '0.6.7'
+  gem.version = '0.6.8'
   gem.add_dependency('genesis_promptcli', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('genesis_retryingfetcher', '~> 0.4', '>= 0.4.0')
   gem.add_dependency('collins_client', '~> 0.2', '>= 0.2.0')

--- a/src/framework/lib/genesisframework/utils.rb
+++ b/src/framework/lib/genesisframework/utils.rb
@@ -35,13 +35,12 @@ module Genesis
 
       def self.facter
         if config_cache.fetch(:facter_cache, true)
-          Facter.to_hash
-        else
           if @@facter.nil?
             @@facter = Facter.to_hash
           end
-
           @@facter
+        else
+          Facter.to_hash
         end
       end
 

--- a/tasks/DisableCpuFreqScaling.rb
+++ b/tasks/DisableCpuFreqScaling.rb
@@ -1,0 +1,16 @@
+class DisableCpuFreqScaling
+  include Genesis::Framework::Task
+
+  init do
+    log "Make sure acpi-cpufreq is enabled" 
+    run_cmd('modprobe acpi-cpufreq')
+  end
+
+  run do
+    num_procs = run_cmd('cat /proc/cpuinfo | grep processor | wc -l')
+    (0..(num_procs.to_i - 1)).each do |n|
+      run_cmd("echo 'performance' > /sys/devices/system/cpu/cpu#{n}/cpufreq/scaling_governor")
+    end
+  end
+
+end

--- a/tasks/DisableCpuFreqScaling.rb
+++ b/tasks/DisableCpuFreqScaling.rb
@@ -6,20 +6,19 @@ class DisableCpuFreqScaling
   include Genesis::Framework::Task
 
   init do
-    log "Make sure acpi-cpufreq is enabled"
     run_cmd('modprobe acpi-cpufreq')
   end
 
   run do
-    cpu_dirs = '/sys/devices/system/cpu/cpu[0-9]*'
+    cpu_dirs = '/sys/devices/system/cpu/cpu[0-9]*/cpufreq'
     Dir.glob(cpu_dirs).each do |dirname|
-      File.write("#{dirname}/cpufreq/scaling_governor", 'performance')
+      File.write("#{dirname}/scaling_governor", 'performance')
     end
 
     # Verify CPUs set to max freq 
-    Dir.glob(cpu_dirs).each do |dirname|
-      max = File.read("#{dirname}/cpufreq/cpuinfo_max_freq").strip
-      cur = File.read("#{dirname}/cpufreq/cpuinfo_cur_freq").strip
+    Dir.glob("#{cpu_dirs}").each do |dirname|
+      max = File.read("#{dirname}/cpuinfo_max_freq").strip
+      cur = File.read("#{dirname}/cpuinfo_cur_freq").strip
       raise "Max CPU frequency did not take" unless max == cur
     end
   end

--- a/tasks/DisableCpuFreqScaling.rb
+++ b/tasks/DisableCpuFreqScaling.rb
@@ -9,7 +9,7 @@ class DisableCpuFreqScaling
   run do
     cpu_dirs = '/sys/devices/system/cpu/cpu[0-9]*'
     Dir.glob(cpu_dirs).each do |dirname|
-      File.open("#{dirname}/cpufreq/scaling_governor", 'w') { |f| f.write('performance') }
+      File.write("#{dirname}/cpufreq/scaling_governor", 'performance')
     end
 
     # Verify CPUs set to max freq 
@@ -19,6 +19,5 @@ class DisableCpuFreqScaling
       raise "Max CPU frequency did not take" unless max == cur
     end
   end
-
 end
 

--- a/tasks/DisableCpuFreqScaling.rb
+++ b/tasks/DisableCpuFreqScaling.rb
@@ -1,3 +1,7 @@
+# For background on this read the following two links
+# https://wiki.gentoo.org/wiki/Power_management/Processor
+# https://wiki.archlinux.org/index.php/CPU_frequency_scaling
+
 class DisableCpuFreqScaling
   include Genesis::Framework::Task
 

--- a/tasks/DisableCpuFreqScaling.rb
+++ b/tasks/DisableCpuFreqScaling.rb
@@ -2,15 +2,25 @@ class DisableCpuFreqScaling
   include Genesis::Framework::Task
 
   init do
-    log "Make sure acpi-cpufreq is enabled" 
+    log "Make sure acpi-cpufreq is enabled"
     run_cmd('modprobe acpi-cpufreq')
   end
 
   run do
-    num_procs = run_cmd('cat /proc/cpuinfo | grep processor | wc -l')
-    (0..(num_procs.to_i - 1)).each do |n|
-      run_cmd("echo 'performance' > /sys/devices/system/cpu/cpu#{n}/cpufreq/scaling_governor")
+    cpu_dirs = '/sys/devices/system/cpu/cpu[0-9]*'
+    Dir.glob(cpu_dirs).each do |dirname|
+      File.open("#{dirname}/cpufreq/scaling_governor", 'w') { |f| f.write('performance') }
+    end
+
+    log 'Syncing files to disk and sleep 5'
+
+    # Verify CPUs set to max freq 
+    Dir.glob(cpu_dirs).each do |dirname|
+      max = File.read("#{dirname}/cpufreq/cpuinfo_max_freq").strip
+      cur = File.read("#{dirname}/cpufreq/cpuinfo_cur_freq").strip
+      raise "Max CPU frequency did not take" unless max == cur
     end
   end
 
 end
+

--- a/tasks/DisableCpuFreqScaling.rb
+++ b/tasks/DisableCpuFreqScaling.rb
@@ -12,8 +12,6 @@ class DisableCpuFreqScaling
       File.open("#{dirname}/cpufreq/scaling_governor", 'w') { |f| f.write('performance') }
     end
 
-    log 'Syncing files to disk and sleep 5'
-
     # Verify CPUs set to max freq 
     Dir.glob(cpu_dirs).each do |dirname|
       max = File.read("#{dirname}/cpufreq/cpuinfo_max_freq").strip

--- a/tasks/targets.yaml
+++ b/tasks/targets.yaml
@@ -4,6 +4,7 @@ intake:
   - SetupNTP
   - IpmiStart
   - AssetCreation
+  - DisableCpuFreqScaling
   - BiosConfigrC6105
   - BiosConfigrR720
   - FixDellFatPartitions


### PR DESCRIPTION
This task puts all CPUs into performance mode so they report back
the max MHz that they are capable of achieving.

Possibly a more elegant way to do this but I went for what required the least dependencies.

Closes #65 

Before running
```
[root@genesis tasks]# cat /proc/cpuinfo | grep "cpu MH"
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
cpu MHz		: 2526.971
```

After Running
```
[root@genesis tasks]# cat /proc/cpuinfo | grep "cpu MH"
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
cpu MHz		: 2528.000
```

lshw also reports 2528 after this task is run.