### PR TITLE
[Framework] Utils - Collins client config

### DIFF
--- a/src/framework/genesis_framework.gemspec
+++ b/src/framework/genesis_framework.gemspec
@@ -7,12 +7,13 @@ Gem::Specification.new do |gem|
   gem.authors = ["Jeremy Johnstone", 'Roy Marantz', 'Gabe Conradi']
   gem.email = 'opensourcesoftware@tumblr.com'
 
-  gem.date = '2017-06-08'
-  gem.version = '0.6.10'
+  gem.date = '2017-06-15'
+  gem.version = '0.6.11'
   gem.add_dependency('genesis_promptcli', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('genesis_retryingfetcher', '~> 0.4', '>= 0.4.0')
   gem.add_dependency('collins_client', '~> 0.2', '>= 0.2.0')
   gem.add_dependency('facter', '~> 2.0', '>= 2.0.0')
+  gem.add_dependency('hashwithindifferentaccess')
 
   gem.files = Dir["bin/*", "lib/**/*", "*.md", "*.txt", "test/*.rb"].reject do |f|
     f[%r{~$|^#|\.bak$}]

--- a/src/framework/lib/genesisframework/utils.rb
+++ b/src/framework/lib/genesisframework/utils.rb
@@ -1,11 +1,12 @@
 require 'collins_client'
 require 'facter'
+require 'hashwithindifferentaccess'
 
 module Genesis
   module Framework
     module Utils
 
-      @@config_cache = Hash.new
+      @@config_cache = HashWithIndifferentAccess.new
       @@collins_conn = nil
       @@facter = nil
       @@loggers = nil

--- a/src/framework/lib/genesisframework/utils.rb
+++ b/src/framework/lib/genesisframework/utils.rb
@@ -28,12 +28,10 @@ module Genesis
 
       def self.collins
         if @@collins_conn.nil?
-          # http://www.rubydoc.info/gems/collins_client/0.2.17/Collins%2FClient:initialize
-          cfg = {
-            :host => self.config_cache['collins']['host'],
-            :username => self.config_cache['collins']['username'],
-            :password => self.config_cache['collins']['password']
-          }
+
+          # Collins_client initialization
+          # http://www.rubydoc.info/gems/collins_client/0.2.17/Collins/Client#initialize-instance_method
+          cfg = self.config_cache[:collins]
           @@collins_conn = ::Collins::Client.new(cfg)
         end
 


### PR DESCRIPTION
* Cfg is now using anything the user will put in Genesis config under ':collins' key
* Use a symbol for Collins key like everything else in Genesis config
(Even in testenv it is that way: https://github.com/tumblr/genesis/blob/master/testenv/bootbox/puppet/modules/genesis/templates/config.yaml.erb#L23-L24)