### PR TITLE
Allow for /conf to not exist when building genesis

### DIFF
--- a/bootcd/create-image.sh
+++ b/bootcd/create-image.sh
@@ -65,7 +65,7 @@ perl -pe "s/%%LocalNameservers%%/$ns/" genesis.ks.template > "$tmpdir/genesis.ks
 # which should be bind mounted via: docker run -v /Some/Dir:/conf:ro ....
 # are inserted in the genesis.ks file replacing the %%ExtraPostContent%%
 # line in that file.
-extras=( $(find /conf -name \*.content 2>/dev/null) )
+extras=( $(find /conf -name \*.content 2>/dev/null || true) )
 if [[ ${#extras[@]} -gt 0 ]]; then
    echo '### inserting Extra Post Content'
    sed -i -e "


### PR DESCRIPTION
Because of `set -e`, `find` on a missing directory will return a non-zero exit code.  This prevents genesis from building.  Adding a `|| true` to the command allows it to work.